### PR TITLE
Refactor persistence.xml to use env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Server Application
+
+## Database Configuration
+
+This project requires database connection parameters to be supplied through environment variables before building or deploying.
+
+Set the following variables in your shell or deployment environment:
+
+- `DB_URL` – JDBC URL to your database (e.g., `jdbc:oracle:thin:@localhost:1521/XE`)
+- `DB_USER` – database username
+- `DB_PASS` – database password
+
+Example for Unix shells:
+
+```bash
+export DB_URL="jdbc:oracle:thin:@localhost:1521/XE"
+export DB_USER="myuser"
+export DB_PASS="mypassword"
+```
+
+Ensure these variables are available to the build process (e.g., Maven) and the application server so that the placeholders in `persistence.xml` are resolved correctly.

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -4,12 +4,15 @@
              xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence https://jakarta.ee/xml/ns/persistence/persistence_3_0.xsd"
              version="3.0">
   <persistence-unit name="default">
-    <jta-data-source>java:/OracleDS</jta-data-source>
     <properties>
       <property name="hibernate.hbm2ddl.auto" value=""/>
       <property name="hibernate.show_sql" value="false"/>
       <property name="hibernate.format_sql" value="false"/>
       <property name="hibernate.dialect" value="org.hibernate.dialect.OracleDialect"/>
+      <!-- Database connection parameters -->
+      <property name="jakarta.persistence.jdbc.url" value="${DB_URL}"/>
+      <property name="jakarta.persistence.jdbc.user" value="${DB_USER}"/>
+      <property name="jakarta.persistence.jdbc.password" value="${DB_PASS}"/>
     </properties>
   </persistence-unit>
 </persistence>


### PR DESCRIPTION
## Summary
- use environment variables in `persistence.xml` for DB connection
- document required environment variables in new README

## Testing
- `mvn -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68684b300ad88324af27730e3ae12dd3