### PR TITLE
Add jacoco skip configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# backPFT
+
+This project uses the `jacoco-maven-plugin` for code coverage reports. In offline environments you can skip JaCoCo execution using:
+
+```bash
+mvn -Djacoco.skip=true <goal>
+```
+
+Replace `<goal>` with your desired Maven goal, for example `package`:
+
+```bash
+mvn -Djacoco.skip=true package
+```

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,8 @@
         <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.source>17</maven.compiler.source>
         <junit.version>5.9.2</junit.version>
+        <!-- property to optionally skip jacoco execution -->
+        <jacoco.skip>false</jacoco.skip>
     </properties>
 
     <dependencies>
@@ -221,6 +223,9 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>0.8.7</version>
+                <configuration>
+                    <skip>${jacoco.skip}</skip>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
## Summary
- allow skipping jacoco plugin via `jacoco.skip` property
- add README with offline build example

## Testing
- `mvn -q -Djacoco.skip=true test` *(fails: Plugin org.jacoco could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68684b37a27c8324b8f10a82c99c5b5b