### PR TITLE
Fix JwtService to use common secret key

### DIFF
--- a/src/main/java/codigocreativo/uy/servidorapp/jwt/JwtService.java
+++ b/src/main/java/codigocreativo/uy/servidorapp/jwt/JwtService.java
@@ -5,8 +5,6 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
-import java.util.Optional;
-
 import java.security.Key;
 import java.util.Date;
 
@@ -14,18 +12,9 @@ import codigocreativo.uy.servidorapp.jwt.SecretKeyUtil;
 
 @Stateless
 public class JwtService {
-
-
-   
-
-    // Decodificar la clave secreta en Base64
-    private static final String DEFAULT_SECRET_KEY = "VGhpc0lzQTMyQnl0ZUxvbmdTZWNyZXRLZXlGb3JKV1Q=";
-
-    private final Key secretKey = Keys.hmacShaKeyFor(
-            DatatypeConverter.parseBase64Binary(
-                    Optional.ofNullable(System.getenv("SECRET_KEY"))
-                            .orElse(DEFAULT_SECRET_KEY)));
-
+    /** Signing key used for token generation and validation. */
+    private final Key secretKey =
+            Keys.hmacShaKeyFor(SecretKeyUtil.getSecretKeyBytes());
 
     public String generateToken(String email, String nombrePerfil) {
         try {


### PR DESCRIPTION
## Summary
- remove DEFAULT_SECRET_KEY from `JwtService`
- use `SecretKeyUtil.getSecretKeyBytes()` for JWT signing

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.jacoco:jacoco-maven-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68686308230483249c281f8c10f742b8