### PR TITLE
Align JwtTokenFilterTest secret key with production code

### DIFF
--- a/src/test/java/codigocreativo/uy/servidorapp/jwt/JwtTokenFilterTest.java
+++ b/src/test/java/codigocreativo/uy/servidorapp/jwt/JwtTokenFilterTest.java
@@ -56,7 +56,9 @@ class JwtTokenFilterTest {
         when(requestContext.getUriInfo()).thenReturn(uriInfo);
 
 
-        key = Keys.hmacShaKeyFor(Base64.getDecoder().decode("VGhpc0lzQTMyQnl0ZUxvbmdTZWNyZXRLZXlGb3JKV1Q="));
+        // Use the same secret key mechanism as the production code to avoid
+        // mismatches when generating test tokens
+        key = Keys.hmacShaKeyFor(SecretKeyUtil.getSecretKeyBytes());
 
     }
 


### PR DESCRIPTION
## Summary
- use SecretKeyUtil in JwtTokenFilterTest so tests sign tokens with same key as JwtTokenFilter

## Testing
- `mvn -q test` *(fails: Plugin org.jacoco:jacoco-maven-plugin could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_686864cd7e388324a03b5868ae82aebc