### PR TITLE
Remove unused default JWT secret

### DIFF
--- a/src/main/java/codigocreativo/uy/servidorapp/filtros/JwtTokenFilter.java
+++ b/src/main/java/codigocreativo/uy/servidorapp/filtros/JwtTokenFilter.java
@@ -28,10 +28,6 @@ public class JwtTokenFilter implements ContainerRequestFilter {
 
     private static final Logger LOGGER = Logger.getLogger(JwtTokenFilter.class.getName());
 
-
-    private static final String DEFAULT_SECRET_KEY = "VGhpc0lzQTMyQnl0ZUxvbmdTZWNyZXRLZXlGb3JKV1Q=";
-    private static final String SECRET_KEY = Optional.ofNullable(System.getenv("SECRET_KEY")).orElse(DEFAULT_SECRET_KEY);
-
     private static final String ERROR_JSON_FORMAT = "{\"error\":\"%s\"}";
 
     public static class TokenValidationException extends Exception {


### PR DESCRIPTION
## Summary
- remove the unused `DEFAULT_SECRET_KEY` field

## Testing
- `mvn -q test` *(fails: could not resolve jacoco plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68686583a53c8324b9eea54dd3d50216