### PR TITLE
Add env flag to disable JWT auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,17 @@ Replace `<goal>` with your desired Maven goal, for example `package`:
 ```bash
 mvn -Djacoco.skip=true package
 ```
+
+## Disabling JWT authentication locally
+
+During local development you might want to bypass the JWT filter. Set the
+`DISABLE_JWT_AUTH` environment variable to `"true"` before starting the
+application. When this variable is enabled, a warning is logged and the
+`JwtTokenFilter` will skip authentication checks.
+
+Example:
+
+```bash
+export DISABLE_JWT_AUTH=true
+mvn package
+``` 

--- a/src/main/java/codigocreativo/uy/servidorapp/filtros/JwtTokenFilter.java
+++ b/src/main/java/codigocreativo/uy/servidorapp/filtros/JwtTokenFilter.java
@@ -55,6 +55,14 @@ public class JwtTokenFilter implements ContainerRequestFilter {
 
     @Override
     public void filter(ContainerRequestContext requestContext) {
+        String disableAuth = Optional.ofNullable(System.getenv("DISABLE_JWT_AUTH"))
+                .orElse("false");
+
+        if ("true".equalsIgnoreCase(disableAuth)) {
+            LOGGER.warning("JWT authentication disabled via DISABLE_JWT_AUTH");
+            return;
+        }
+
         String path = requestContext.getUriInfo().getPath();
         LOGGER.info("Procesando petición para el path: " + path);
 

--- a/src/main/java/codigocreativo/uy/servidorapp/ws/MiApp.java
+++ b/src/main/java/codigocreativo/uy/servidorapp/ws/MiApp.java
@@ -10,6 +10,7 @@ import jakarta.ws.rs.core.Application;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.Optional;
 
 @ApplicationPath("/api")
 public class MiApp extends Application {
@@ -36,7 +37,11 @@ public class MiApp extends Application {
         
         // Filtros y configuraciones
         resources.add(AuditoriaFilter.class);
-        resources.add(JwtTokenFilter.class);
+        String disableAuth = Optional.ofNullable(System.getenv("DISABLE_JWT_AUTH"))
+                .orElse("false");
+        if (!"true".equalsIgnoreCase(disableAuth)) {
+            resources.add(JwtTokenFilter.class);
+        }
         resources.add(CORSFilter.class);
         resources.add(JacksonConfig.class);
         


### PR DESCRIPTION
## Summary
- allow `JwtTokenFilter` to be skipped when `DISABLE_JWT_AUTH` env variable is set to `"true"`
- only register JwtTokenFilter in MiApp when auth is enabled
- document this flag in README

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.jacoco:jacoco-maven-plugin: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686883bd57c08324b3b98ef4b7402fc0